### PR TITLE
Smarter state machine to use internal vbatt when CAN not connected

### DIFF
--- a/firmware/heater_control.cpp
+++ b/firmware/heater_control.cpp
@@ -33,14 +33,17 @@ static HeaterState GetNextState(HeaterState state, HeaterAllow heaterAllowState,
 {
     bool heaterAllowed = heaterAllowState == HeaterAllow::Allowed;
 
-    /* Check battery voltage for thresholds only if there is still no command over CAN */
-    if (heaterAllowState == HeaterAllow::Unknown) {
-        /* measured voltage too low to auto-start heating */
-        if (batteryVoltage < HEATER_BATTETY_OFF_VOLTAGE) {
+    // Check battery voltage for thresholds only if there is still no command over CAN
+    if (heaterAllowState == HeaterAllow::Unknown)
+    {
+        // measured voltage too low to auto-start heating
+        if (batteryVoltage < HEATER_BATTETY_OFF_VOLTAGE)
+        {
             batteryStabTime = batteryStabTimeCounter;
         }
-        /* measured voltage is high enougth to auto-start heating, wait some time to stabilize */
-        if ((batteryVoltage > HEATER_BATTERY_ON_VOLTAGE) && (batteryStabTime > 0)) {
+        // measured voltage is high enougth to auto-start heating, wait some time to stabilize
+        if ((batteryVoltage > HEATER_BATTERY_ON_VOLTAGE) && (batteryStabTime > 0))
+        {
             batteryStabTime--;
         }
         heaterAllowed = batteryStabTime == 0;

--- a/firmware/heater_control.cpp
+++ b/firmware/heater_control.cpp
@@ -24,13 +24,27 @@ enum class HeaterState
 };
 
 constexpr int preheatTimeCounter = HEATER_PREHEAT_TIME / HEATER_CONTROL_PERIOD;
+constexpr int batteryStabTimeCounter = HEATER_BATTERY_STAB_TIME / HEATER_CONTROL_PERIOD;
 static int timeCounter = preheatTimeCounter;
+static int batteryStabTime = batteryStabTimeCounter;
 static float rampVoltage = 0;
 
 static HeaterState GetNextState(HeaterState state, HeaterAllow heaterAllowState, float batteryVoltage, float sensorEsr)
 {
-    // TODO: smarter state machine to use internal vbatt when CAN not connected
     bool heaterAllowed = heaterAllowState == HeaterAllow::Allowed;
+
+    /* Check battery voltage for thresholds only if there is still no command over CAN */
+    if (heaterAllowState == HeaterAllow::Unknown) {
+        /* measured voltage too low to auto-start heating */
+        if (batteryVoltage < HEATER_BATTETY_OFF_VOLTAGE) {
+            batteryStabTime = batteryStabTimeCounter;
+        }
+        /* measured voltage is high enougth to auto-start heating, wait some time to stabilize */
+        if ((batteryVoltage > HEATER_BATTERY_ON_VOLTAGE) && (batteryStabTime > 0)) {
+            batteryStabTime--;
+        }
+        heaterAllowed = batteryStabTime == 0;
+    }
 
     if (!heaterAllowed)
     {

--- a/firmware/wideband_config.h
+++ b/firmware/wideband_config.h
@@ -40,6 +40,12 @@
 #define HEATER_PREHEAT_TIME 5000
 #define HEATER_WARMUP_TIMEOUT 60000
 
+#define HEATER_BATTERY_STAB_TIME	3000
+/* minimal battery voltage to start heating without CAN command */
+#define HEATER_BATTERY_ON_VOLTAGE	9.5
+/* mininal battery voltage to continue heating */
+#define HEATER_BATTETY_OFF_VOLTAGE  8.5
+
 #define HEATER_CLOSED_LOOP_THRESHOLD_ESR 500
 #define HEATER_TARGET_ESR 300
 #define HEATER_OVERHEAT_ESR 150

--- a/firmware/wideband_config.h
+++ b/firmware/wideband_config.h
@@ -41,9 +41,9 @@
 #define HEATER_WARMUP_TIMEOUT 60000
 
 #define HEATER_BATTERY_STAB_TIME	3000
-/* minimal battery voltage to start heating without CAN command */
+// minimal battery voltage to start heating without CAN command
 #define HEATER_BATTERY_ON_VOLTAGE	9.5
-/* mininal battery voltage to continue heating */
+// mininal battery voltage to continue heating
 #define HEATER_BATTETY_OFF_VOLTAGE  8.5
 
 #define HEATER_CLOSED_LOOP_THRESHOLD_ESR 500


### PR DESCRIPTION
Need to be checked on F103 board with no Vbatt divider added to PA5.
Floating input can be readed as non-zero and cause unpredictable Vbatt reading.
Should we enable pull-down on PA5? Will this affect Vbatt measurement accuracy?