### PR TITLE
CAN: rotate mailboxes used for TX

### DIFF
--- a/firmware/can_helper.cpp
+++ b/firmware/can_helper.cpp
@@ -2,6 +2,8 @@
 
 #include <cstring>
 
+static int can1_mailbox = 1;
+
 CanTxMessage::CanTxMessage(uint32_t eid, uint8_t dlc, bool isExtended) {
 	m_frame.IDE = isExtended ? CAN_IDE_EXT : CAN_IDE_STD;
 	m_frame.EID = eid;
@@ -12,7 +14,13 @@ CanTxMessage::CanTxMessage(uint32_t eid, uint8_t dlc, bool isExtended) {
 
 CanTxMessage::~CanTxMessage() {
 	// 100 ms timeout
-	canTransmitTimeout(&CAND1, CAN_ANY_MAILBOX, &m_frame, TIME_IMMEDIATE);
+	canTransmitTimeout(&CAND1, can1_mailbox, &m_frame, TIME_MS2I(100));
+
+	/* rotate mailboxes */
+	can1_mailbox++;
+	if (can1_mailbox == 4) {
+		can1_mailbox = 1;
+	}
 }
 
 uint8_t& CanTxMessage::operator[](size_t index) {

--- a/firmware/can_helper.cpp
+++ b/firmware/can_helper.cpp
@@ -18,7 +18,7 @@ CanTxMessage::~CanTxMessage() {
 
 	/* rotate mailboxes */
 	can1_mailbox++;
-	if (can1_mailbox == 4) {
+	if (can1_mailbox > CAN_TX_MAILBOXES) {
 		can1_mailbox = 1;
 	}
 }


### PR DESCRIPTION
To avoid overwrite of not-yet-transmitted message by next one.