### PR TITLE
Makefile: add ChibiOS C++ wrappers

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -120,6 +120,7 @@ include $(CHIBIOS)/os/hal/osal/rt-nil/osal.mk
 include $(CHIBIOS)/os/rt/rt.mk
 # Other files (optional).
 include $(CHIBIOS)/os/hal/lib/streams/streams.mk
+include $(CHIBIOS)/os/various/cpp_wrappers/chcpp.mk
 
 # include board.mk that sets per-board options
 include $(BOARDDIR)/board.mk


### PR DESCRIPTION
After adding max31855 driver linker needs __cxa_pure_virtual.
I'm not a C++ expert, but this wrapper already exist in ChibiOS
so lets use it.