### PR TITLE
f1_rev and threads

### DIFF
--- a/firmware/auxout.cpp
+++ b/firmware/auxout.cpp
@@ -151,6 +151,8 @@ void AuxOutThread(void*)
 {
     const auto cfg = GetConfiguration();
 
+    chRegSetThreadName("Aux out");
+
     while(1)
     {
         for (int ch = 0; ch < AFR_CHANNELS; ch++)

--- a/firmware/boards/f1_dual/chconf.h
+++ b/firmware/boards/f1_dual/chconf.h
@@ -183,7 +183,7 @@ typedef int pid_t;
  * @note    The default is @p TRUE.
  */
 #if !defined(CH_CFG_USE_REGISTRY)
-#define CH_CFG_USE_REGISTRY                 FALSE
+#define CH_CFG_USE_REGISTRY                 TRUE
 #endif
 
 /**

--- a/firmware/boards/f1_rev3/board.h
+++ b/firmware/boards/f1_rev3/board.h
@@ -109,7 +109,7 @@
  * PB12 - Nernsr_4.2_esr_drive      (digital input, no pull) - keep high-Z after power on
  * PB13..PB15 - unused
  */
-#define VAL_GPIOBCRL            0x8A888200      /*  PB7...PB0 */
+#define VAL_GPIOBCRL            0x8B888200      /*  PB7...PB0 */
 #define VAL_GPIOBCRH            0x88843488      /* PB15...PB8 */
 #define VAL_GPIOBODR            0x0000FFFF
 

--- a/firmware/boards/f1_rev3/chconf.h
+++ b/firmware/boards/f1_rev3/chconf.h
@@ -183,7 +183,7 @@ typedef int pid_t;
  * @note    The default is @p TRUE.
  */
 #if !defined(CH_CFG_USE_REGISTRY)
-#define CH_CFG_USE_REGISTRY                 FALSE
+#define CH_CFG_USE_REGISTRY                 TRUE
 #endif
 
 /**

--- a/firmware/can.cpp
+++ b/firmware/can.cpp
@@ -17,6 +17,8 @@ static Configuration* configuration;
 static THD_WORKING_AREA(waCanTxThread, 256);
 void CanTxThread(void*)
 {
+    chRegSetThreadName("CAN Tx");
+
     while(1)
     {
         SendRusefiFormat(configuration->CanIndexOffset);
@@ -45,6 +47,8 @@ static float remoteBatteryVoltage = 0;
 static THD_WORKING_AREA(waCanRxThread, 512);
 void CanRxThread(void*)
 {
+    chRegSetThreadName("CAN Rx");
+
     while(1)
     {
         CANRxFrame frame;

--- a/firmware/heater_control.cpp
+++ b/firmware/heater_control.cpp
@@ -196,6 +196,8 @@ static void HeaterThread(void*)
 {
     int ch;
 
+    chRegSetThreadName("Heater");
+
     // Wait for temperature sensing to stabilize so we don't
     // immediately think we overshot the target temperature
     chThdSleepMilliseconds(1000);

--- a/firmware/pump_control.cpp
+++ b/firmware/pump_control.cpp
@@ -26,6 +26,8 @@ static struct pump_control_state state[AFR_CHANNELS] =
 static THD_WORKING_AREA(waPumpThread, 256);
 static void PumpThread(void*)
 {
+    chRegSetThreadName("Pump");
+
     while(true)
     {
         for (int ch = 0; ch < AFR_CHANNELS; ch++)

--- a/firmware/sampling.cpp
+++ b/firmware/sampling.cpp
@@ -37,6 +37,8 @@ static void SamplingThread(void*)
     float r_2[AFR_CHANNELS] = {0};
     float r_3[AFR_CHANNELS] = {0};
 
+    chRegSetThreadName("Sampling");
+
     /* GD32: Insert 20us delay after ADC enable */
     chThdSleepMilliseconds(1);
 

--- a/firmware/uart.cpp
+++ b/firmware/uart.cpp
@@ -28,6 +28,8 @@ static char printBuffer[200];
 static THD_WORKING_AREA(waUartThread, 512);
 static void UartThread(void*)
 {
+    chRegSetThreadName("UART debug");
+
     // in UART_DEBUG mode we only support Serial - this file name here has a bit of a confusing naming
     sdStart(&SD1, &cfg);
 


### PR DESCRIPTION
Set high speed mode for PWM gpio to source more current for VND14

Enable CH_CFG_USE_REGISTRY for all F1 boards and set name for all thread. So GDB can show thread names.