### PR TITLE
heater_control: smarter PWM duty limiting for VBat measurement

### DIFF
--- a/firmware/heater_control.cpp
+++ b/firmware/heater_control.cpp
@@ -76,6 +76,9 @@ struct heater_state {
     int batteryStabTime;
     float rampVoltage;
     HeaterState heaterState;
+#ifdef HEATER_MAX_DUTY
+    int cycle;
+#endif
     uint8_t ch;
     uint8_t pwm_ch;
 };
@@ -271,8 +274,12 @@ static void HeaterThread(void*)
             float duty = voltageRatio * voltageRatio;
 
             #ifdef HEATER_MAX_DUTY
-            if (duty > HEATER_MAX_DUTY) {
-                duty = HEATER_MAX_DUTY;
+            s.cycle++;
+            // limit PWM each 10th cycle (2 time per second) to measure heater supply voltage throuth "Heater-"
+            if ((s.cycle % 10) == 0) {
+                if (duty > HEATER_MAX_DUTY) {
+                    duty = HEATER_MAX_DUTY;
+                }
             }
             #endif
 


### PR DESCRIPTION
Apply duty cycle limit only 2 cycles of 20 (per second). This allows 100% duty PWM while heating sensor on low VBat.

(cherry picked from commit 28a01bd6c3dad0d0712a3b6412b9e87fe514555b)