### PR TITLE
GetSensorTemperature() is supported for LSU4.9 only

### DIFF
--- a/firmware/sampling.cpp
+++ b/firmware/sampling.cpp
@@ -126,7 +126,11 @@ float GetSensorTemperature(int ch)
         return 0;
     }
 
-    return interpolate2d(esr, lsu49TempBins, lsu49TempValues);
+    if (GetSensorType() == SensorType::LSU49)
+        return interpolate2d(esr, lsu49TempBins, lsu49TempValues);
+
+    // TODO: implement for LSU4.2 and ADV
+    return 0;
 }
 
 float GetNernstDc(int ch)


### PR DESCRIPTION
(cherry picked from commit 4bc6bbf13ae6d166724f64f161a61b7e56dc65ed)