### PR TITLE
fail fast

### DIFF
--- a/firmware/boards/f0_module/build_wideband.sh
+++ b/firmware/boards/f0_module/build_wideband.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -o pipefail
 
 # first build the bootloader
 cd bootloader

--- a/firmware/boards/f0_module/build_wideband.sh
+++ b/firmware/boards/f0_module/build_wideband.sh
@@ -24,6 +24,7 @@ arm-none-eabi-objcopy -I binary -O binary --gap-fill 0xFF --pad-to 0x63FC build/
 
 # compute the crc and write that to a file (in binary)
 crc32 build/wideband_fullsize_nocrc.bin | xxd -r -p - > build/wideband_crc.bin
+[ $? -eq 0 ] || { echo "crc32 computation failed"; exit 1; }
 
 # Now glue the image and CRC together
 cat build/wideband_fullsize_nocrc.bin build/wideband_crc.bin > build/wideband_image.bin


### PR DESCRIPTION
``command not found`` should cause stuff to fail?
``command not found`` should be addressed?

![image](https://user-images.githubusercontent.com/48498823/223088466-bea5d3df-9498-4aae-bd75-4f4aa18250a4.png)
