### PR TITLE
f1_rev3: used MCU has gpio port F and G (in bigger package)

### DIFF
--- a/firmware/boards/f1_rev3/board.c
+++ b/firmware/boards/f1_rev3/board.c
@@ -30,6 +30,9 @@ const PALConfig pal_default_config =
   {VAL_GPIOCODR, VAL_GPIOCCRL, VAL_GPIOCCRH},
   {VAL_GPIODODR, VAL_GPIODCRL, VAL_GPIODCRH},
   {VAL_GPIOEODR, VAL_GPIOECRL, VAL_GPIOECRH},
+  /* Following GPIO ports are not balled out on 64 pin package, but still needs to be set to safe state */
+  {VAL_GPIOFODR, VAL_GPIOFCRL, VAL_GPIOFCRH},
+  {VAL_GPIOGODR, VAL_GPIOGCRL, VAL_GPIOGCRH},
 };
 #endif
 

--- a/firmware/boards/f1_rev3/board.h
+++ b/firmware/boards/f1_rev3/board.h
@@ -147,6 +147,22 @@
 #define VAL_GPIOEODR            0x0000FFFF
 
 /*
+ * Port F setup.
+ * Everything input with pull-up expect:
+ */
+#define VAL_GPIOFCRL            0x88888888      /*  PF7...PF0 */
+#define VAL_GPIOFCRH            0x88888888      /* PF15...PF8 */
+#define VAL_GPIOFODR            0xFFFFFFFF
+
+/*
+ * Port G setup.
+ * Everything input with pull-up expect:
+ */
+#define VAL_GPIOGCRL            0x88888888      /*  PG7...PG0 */
+#define VAL_GPIOGCRH            0x88888888      /* PG15...PG8 */
+#define VAL_GPIOGODR            0xFFFFFFFF
+
+/*
  * USB bus activation macro, required by the USB driver.
  */
 #define usb_lld_connect_bus(usbp)


### PR DESCRIPTION
Set safe state for gpio ports F and G to keep compiler happy.