### PR TITLE
f1_common: default AUXOUT value is AFR voltage

### DIFF
--- a/firmware/boards/f1_common/f1_port.cpp
+++ b/firmware/boards/f1_common/f1_port.cpp
@@ -30,8 +30,19 @@ static Configuration cfg;
 // Configuration defaults
 void Configuration::LoadDefaults()
 {
+    int i;
+
     CanIndexOffset = 0;
     sensorType = BOARD_DEFAULT_SENSOR_TYPE;
+
+    /* default auxout curve is 0..5V for AFR 8.5 to 18.0
+     * default auxout[n] input is AFR[n] */
+    for (i = 0; i < 8; i++) {
+        auxOutBins[0][i] = auxOutBins[1][i] = 8.5 + (18.0 - 8.5) / 7 * i;
+        auxOutValues[0][i] = auxOutValues[1][i] = 0.0 + (5.0 - 0.0) / 7 * i;
+    }
+    auxOutputSource[0] = AuxOutputMode::Afr0;
+    auxOutputSource[1] = AuxOutputMode::Afr1;
 
     /* Finaly */
     Tag = ExpectedTag;


### PR DESCRIPTION
with 'default' scaling 8.5 to 18.0 AFR is represented with 0.0 to 5.0V

(cherry picked from commit 5f18b10147fc72a8c5db2e8d665cc507125de0f0)