### PR TITLE
dac: fix overflow

### DIFF
--- a/firmware/dac.cpp
+++ b/firmware/dac.cpp
@@ -21,7 +21,7 @@ void Dac::SetVoltage(int channel, float voltage) {
     voltage = clampF(0, voltage, VCC_VOLTS);
     m_voltageFloat[channel] = voltage;
 
-    dacPutChannelX(m_driver, channel, voltage / VCC_VOLTS * (1 << 12));
+    dacPutChannelX(m_driver, channel, voltage / VCC_VOLTS * ((1 << 12) - 1));
 }
 
 float Dac::GetLastVoltage(int channel)


### PR DESCRIPTION
Here is a reason of my wierd 1.0+ V on Nernst. When max positive pump current is requested 4096 instead of 4095 was written into DAC causing max negative current to pump.