### PR TITLE
f1_common: fix MFS flash allocation for STM32F103RCT6 used on dual_rev1

### DIFF
--- a/firmware/boards/f1_common/f1_port.cpp
+++ b/firmware/boards/f1_common/f1_port.cpp
@@ -6,15 +6,30 @@
 #include "hal_mfs.h"
 
 // Storage
-
+// TODO: runtime detection?
 static const MFSConfig mfscfg1 = {
     .flashp           = (BaseFlash *)&EFLD1,
     .erased           = 0xFFFFFFFFU,
+#ifdef STM32F103xB
+    /* 128K flash device with 1K pages
+     * use last 8 pages for settings
+     * one bank is 4K */
     .bank_size        = 4096U,
     .bank0_start      = 120U,
     .bank0_sectors    = 4U,
     .bank1_start      = 124U,
     .bank1_sectors    = 4U
+#endif
+#ifdef STM32F103xE
+    /* 256K flash device with 2K pages
+     * use last 8 pages for settings
+     * one bank is 8K */
+    .bank_size        = 8096U,
+    .bank0_start      = 120U,
+    .bank0_sectors    = 4U,
+    .bank1_start      = 124U,
+    .bank1_sectors    = 4U
+#endif
 };
 
 static MFSDriver mfs1;

--- a/firmware/boards/f1_dual_rev1/board.h
+++ b/firmware/boards/f1_dual_rev1/board.h
@@ -41,11 +41,9 @@
 
 /*
  * MCU type, supported types are defined in ./os/hal/platforms/hal_lld.h.
- */
+ * see ChibiOS/os/common/ext/ST/STM32F1xx/stm32f1xx.h:
+ * STM32F103xE is for STM32F103RC */
 #define STM32F103xE
-// TODO:
-//#define STM32F103xC
-
 /*
  * IO pins assignments.
  */


### PR DESCRIPTION
(cherry picked from commit 258d33e8a7b79846afd4e0db791d87476b9d2041)