### PR TITLE
remove NoHeaterSupply state

### DIFF
--- a/firmware/heater_control.cpp
+++ b/firmware/heater_control.cpp
@@ -48,7 +48,6 @@ HeaterState HeaterControllerBase::GetNextState(HeaterState currentState, HeaterA
         if (batteryVoltage < HEATER_BATTETY_OFF_VOLTAGE)
         {
             m_batteryStableTimer.reset();
-            return HeaterState::NoHeaterSupply;
         }
         else if (batteryVoltage > HEATER_BATTERY_ON_VOLTAGE)
         {
@@ -113,8 +112,6 @@ HeaterState HeaterControllerBase::GetNextState(HeaterState currentState, HeaterA
 
             break;
         case HeaterState::Stopped:
-        case HeaterState::NoHeaterSupply:
-            /* nop */
             break;
     }
 
@@ -146,9 +143,6 @@ float HeaterControllerBase::GetVoltageForState(HeaterState state, float sensorEs
             return 7.5f - heaterPid.GetOutput(m_targetEsr, sensorEsr);
         case HeaterState::Stopped:
             // Something has gone wrong, turn off the heater.
-            return 0;
-        case HeaterState::NoHeaterSupply:
-            // No/too low heater supply - disable output
             return 0;
     }
 
@@ -212,8 +206,6 @@ const char* describeHeaterState(HeaterState state)
             return "ClosedLoop";
         case HeaterState::Stopped:
             return "Stopped";
-        case HeaterState::NoHeaterSupply:
-            return "NoHeaterSupply";
     }
 
     return "Unknown";

--- a/firmware/heater_control.h
+++ b/firmware/heater_control.h
@@ -14,7 +14,6 @@ enum class HeaterState
     WarmupRamp,
     ClosedLoop,
     Stopped,
-    NoHeaterSupply,
 };
 
 struct ISampler;

--- a/test/tests/test_heater.cpp
+++ b/test/tests/test_heater.cpp
@@ -49,7 +49,6 @@ TEST(HeaterStateOutput, Cases)
     MockHeater dut;
 
     EXPECT_EQ(0, dut.GetVoltageForState(HeaterState::Stopped, 0));
-    EXPECT_EQ(0, dut.GetVoltageForState(HeaterState::NoHeaterSupply, 0));
 }
 
 TEST(HeaterStateMachine, PreheatToWarmupTimeout)


### PR DESCRIPTION
We don't really need the NoHeaterSupply state, and it was possible to get stuck there, at least on an F042 with "battery emulation".

The behavior of waiting for supply power still applies: we stick in preheat state until the heater is allowed, either via:
- Command over CAN
- battery voltage is over `HEATER_BATTERY_ON_VOLTAGE` for longer than `HEATER_BATTERY_STAB_TIME`