### PR TITLE
Conditional compile ts

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -157,15 +157,20 @@ CPPSRC = $(ALLCPPSRC) \
           max3185x.cpp \
           uart.cpp \
           auxout.cpp \
-          livedata.cpp \
           indication.cpp \
-          console/binary/tunerstudio.cpp \
-          console/binary/tunerstudio_io.cpp \
-          console/binary/tunerstudio_io_serial.cpp \
-          console/binary/tunerstudio_commands.cpp \
           sampling_thread.cpp \
           heater_thread.cpp \
           main.cpp
+
+ifneq ($(ENABLE_TS),)
+CPPSRC += console/binary/tunerstudio.cpp \
+          console/binary/tunerstudio_io.cpp \
+          console/binary/tunerstudio_io_serial.cpp \
+          console/binary/tunerstudio_commands.cpp \
+          livedata.cpp \
+
+DDEFS += -DTS_ENABLED=TRUE
+endif
 
 # List ASM source files here.
 ASMSRC = $(ALLASMSRC)

--- a/firmware/boards/f0_module/port.cpp
+++ b/firmware/boards/f0_module/port.cpp
@@ -95,7 +95,7 @@ int InitConfiguration()
     return 0;
 }
 
-static Configuration c;
+static Configuration config;
 
 Configuration* GetConfiguration()
 {
@@ -104,7 +104,7 @@ Configuration* GetConfiguration()
     // If config has been written before, use the stored configuration
     if (cfg.IsValid())
     {
-        c = cfg;
+        config = cfg;
     }
 
     // Now, override the index with a hardware-strapped option (if present)
@@ -113,19 +113,19 @@ Configuration* GetConfiguration()
 
     // See https://github.com/mck1117/wideband/issues/11 to explain this madness
     switch (3 * sel1 + sel2) {
-        case 0: c.CanIndexOffset = 2; break;
-        case 1: c.CanIndexOffset = 0; break;
-        case 2: c.CanIndexOffset = 3; break;
-        case 3: c.CanIndexOffset = 4; break;
+        case 0: config.CanIndexOffset = 2; break;
+        case 1: config.CanIndexOffset = 0; break;
+        case 2: config.CanIndexOffset = 3; break;
+        case 3: config.CanIndexOffset = 4; break;
         case 4: /* both floating, do nothing */ break;
-        case 5: c.CanIndexOffset = 1; break;
-        case 6: c.CanIndexOffset = 5; break;
-        case 7: c.CanIndexOffset = 6; break;
-        case 8: c.CanIndexOffset = 7; break;
+        case 5: config.CanIndexOffset = 1; break;
+        case 6: config.CanIndexOffset = 5; break;
+        case 7: config.CanIndexOffset = 6; break;
+        case 8: config.CanIndexOffset = 7; break;
         default: break;
     }
 
-    return &c;
+    return &config;
 }
 
 void SetConfiguration()
@@ -136,7 +136,7 @@ void SetConfiguration()
     // Copy data to flash
     Flash::Write(
         reinterpret_cast<flashaddr_t>(&__configflash__start__),
-        reinterpret_cast<const uint8_t*>(&c),
+        reinterpret_cast<const uint8_t*>(&config),
         sizeof(Configuration)
     );
 }

--- a/firmware/boards/f1_dual/board.mk
+++ b/firmware/boards/f1_dual/board.mk
@@ -1,4 +1,5 @@
 USE_BOOTLOADER = no
+ENABLE_TS = yes
 
 MCU = cortex-m3
 

--- a/firmware/boards/f1_dual_rev1/board.mk
+++ b/firmware/boards/f1_dual_rev1/board.mk
@@ -1,4 +1,5 @@
 USE_BOOTLOADER = no
+ENABLE_TS = yes
 
 MCU = cortex-m3
 

--- a/firmware/boards/f1_rev2/board.mk
+++ b/firmware/boards/f1_rev2/board.mk
@@ -1,4 +1,5 @@
 USE_BOOTLOADER = no
+ENABLE_TS = yes
 
 MCU = cortex-m3
 

--- a/firmware/boards/f1_rev3/board.mk
+++ b/firmware/boards/f1_rev3/board.mk
@@ -1,4 +1,5 @@
 USE_BOOTLOADER = no
+ENABLE_TS = yes
 
 MCU = cortex-m3
 

--- a/firmware/main.cpp
+++ b/firmware/main.cpp
@@ -38,7 +38,9 @@ int main() {
     StartPumpControl();
     InitAuxDac();
 
+#if ENABLE_TS
     startTunerStudioConnectivity();
+#endif
 
     InitCan();
     InitUart();

--- a/firmware/wideband_config.h
+++ b/firmware/wideband_config.h
@@ -48,10 +48,3 @@
 #define HEATER_BATTERY_ON_VOLTAGE	9.5
 // mininal battery voltage to continue heating
 #define HEATER_BATTETY_OFF_VOLTAGE  8.5
-
-// *******************************
-//    TunerStudio configuration
-// *******************************
-#if defined(TS_PRIMARY_UART_PORT) || defined(TS_PRIMARY_SERIAL_PORT)
-#define TS_ENABLED
-#endif


### PR DESCRIPTION
saves memory even if TS isn't used (like on f0)

fix #297 