### PR TITLE
Underheat issue

### DIFF
--- a/firmware/boards/f0_module/wideband_board_config.h
+++ b/firmware/boards/f0_module/wideband_board_config.h
@@ -17,3 +17,9 @@
 //    Nernst voltage & ESR sense
 // *******************************
 #define VM_RESISTOR_VALUE (10)
+
+// *******************************
+// Hack: allow pump driving above this temperature
+// to avoid Vnerns voltage clamp near 0V
+// *******************************
+#define START_PUMP_TEMP_THRESHOLD	(650.0)

--- a/firmware/boards/f0_module/wideband_board_config.h
+++ b/firmware/boards/f0_module/wideband_board_config.h
@@ -19,7 +19,7 @@
 #define VM_RESISTOR_VALUE (10)
 
 // *******************************
-// Hack: allow pump driving above this temperature
-// to avoid Vnerns voltage clamp near 0V
+// Hack: allow pump driving above target temperature
+// minus this offset to avoid Vnerns voltage clamp near 0V
 // *******************************
-#define START_PUMP_TEMP_THRESHOLD	(650.0)
+#define START_PUMP_TEMP_OFFSET	(200.0)

--- a/firmware/heater_control.cpp
+++ b/firmware/heater_control.cpp
@@ -27,6 +27,11 @@ bool HeaterControllerBase::IsRunningClosedLoop() const
     return heaterState == HeaterState::ClosedLoop;
 }
 
+float HeaterControllerBase::GetTargetTemp() const
+{
+    return m_targetTempC;
+}
+
 float HeaterControllerBase::GetHeaterEffectiveVoltage() const
 {
     return heaterVoltage;

--- a/firmware/heater_control.h
+++ b/firmware/heater_control.h
@@ -25,6 +25,7 @@ struct IHeaterController
     virtual bool IsRunningClosedLoop() const = 0;
     virtual float GetHeaterEffectiveVoltage() const = 0;
     virtual HeaterState GetHeaterState() const = 0;
+    virtual float GetTargetTemp() const = 0;
 };
 
 class HeaterControllerBase : public IHeaterController
@@ -37,6 +38,7 @@ public:
     bool IsRunningClosedLoop() const override;
     float GetHeaterEffectiveVoltage() const override;
     HeaterState GetHeaterState() const override;
+    float GetTargetTemp() const override;
 
     virtual void SetDuty(float duty) const = 0;
 

--- a/firmware/pump_control.cpp
+++ b/firmware/pump_control.cpp
@@ -38,7 +38,11 @@ static void PumpThread(void*)
             const auto& heater = GetHeaterController(ch);
 
             // Only actuate pump when running closed loop!
-            if (heater.IsRunningClosedLoop())
+            if (heater.IsRunningClosedLoop() ||
+#ifdef START_PUMP_TEMP_THRESHOLD
+                (sampler.GetSensorTemperature() >= START_PUMP_TEMP_THRESHOLD) ||
+#endif
+                (0))
             {
                 float nernstVoltage = sampler.GetNernstDc();
 

--- a/firmware/pump_control.cpp
+++ b/firmware/pump_control.cpp
@@ -39,8 +39,8 @@ static void PumpThread(void*)
 
             // Only actuate pump when running closed loop!
             if (heater.IsRunningClosedLoop() ||
-#ifdef START_PUMP_TEMP_THRESHOLD
-                (sampler.GetSensorTemperature() >= START_PUMP_TEMP_THRESHOLD) ||
+#ifdef START_PUMP_TEMP_OFFSET
+                (sampler.GetSensorTemperature() >= heater.GetTargetTemp() - START_PUMP_TEMP_OFFSET) ||
 #endif
                 (0))
             {

--- a/firmware/pump_dac.cpp
+++ b/firmware/pump_dac.cpp
@@ -90,7 +90,7 @@ void InitPumpDac()
 
 void SetPumpCurrentTarget(int ch, int32_t microampere)
 {
-#ifndef START_PUMP_TEMP_THRESHOLD
+#ifndef START_PUMP_TEMP_OFFSET
     // Don't allow pump current when the sensor isn't hot
     if (!GetHeaterController(ch).IsRunningClosedLoop())
     {

--- a/firmware/pump_dac.cpp
+++ b/firmware/pump_dac.cpp
@@ -90,11 +90,13 @@ void InitPumpDac()
 
 void SetPumpCurrentTarget(int ch, int32_t microampere)
 {
+#ifndef START_PUMP_TEMP_THRESHOLD
     // Don't allow pump current when the sensor isn't hot
     if (!GetHeaterController(ch).IsRunningClosedLoop())
     {
         microampere = 0;
     }
+#endif
 
     state[ch].curIpump = microampere;
 


### PR DESCRIPTION
Start feeding pump before reaching target temperature (close loop).
Otherwise if mixture is lean, nernst voltage is too close to virtual ground and voltage on output of differential op amp can be clamped at 0V thus causing incorrect ESR measurement.
Incorrectly measured ESR cause incorrect (higher than actual) calculated temperature and SW can fall into overheat state.
Not sure if it is safe to start feeding pump at defined temperature.