### PR TITLE
f0: ld file, 256 bytes is 0x100

### DIFF
--- a/firmware/boards/f0_module/wideband_layout.ld
+++ b/firmware/boards/f0_module/wideband_layout.ld
@@ -17,7 +17,7 @@ MEMORY
     flash6 (rx) : org = 0x00000000, len = 0
     flash7 (rx) : org = 0x00000000, len = 0
     ram_vectors (wx) : org = 0x20000000, len = 256
-    ram0   (wx) : org = 0x20000200, len = 6k - 256
+    ram0   (wx) : org = 0x20000100, len = 6k - 256
     ram1   (wx) : org = 0x00000000, len = 0
     ram2   (wx) : org = 0x00000000, len = 0
     ram3   (wx) : org = 0x00000000, len = 0


### PR DESCRIPTION
This is an actual reason why f1f3c6f cause crash.
718b771 can be reverted again :)